### PR TITLE
Fix compiler warnings

### DIFF
--- a/poly2tri/common/shapes.cc
+++ b/poly2tri/common/shapes.cc
@@ -119,10 +119,6 @@ void Triangle::ClearDelunayEdges()
 Point* Triangle::OppositePoint(Triangle& t, Point& p)
 {
   Point *cw = t.PointCW(p);
-  double x = cw->x;
-  double y = cw->y;
-  x = p.x;
-  y = p.y;
   return PointCW(*cw);
 }
 

--- a/poly2tri/sweep/sweep.cc
+++ b/poly2tri/sweep/sweep.cc
@@ -803,7 +803,7 @@ void Sweep::FlipScanEdgeEvent(SweepContext& tcx, Point& ep, Point& eq, Triangle&
 Sweep::~Sweep() {
 
     // Clean up memory
-    for(int i = 0; i < nodes_.size(); i++) {
+    for(unsigned i = 0; i < nodes_.size(); i++) {
         delete nodes_[i];
     }
 


### PR DESCRIPTION
x and y in Triangle::OppositePoint() are set but not used.

The loop in Sweep::~Sweep() compares signed and unsigned values.